### PR TITLE
chore: update Go to 1.27

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
       - name: Run test
         run: |
           go test ./... --shuffle on --parallel 10 --p 10

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -4,7 +4,7 @@ registries:
   - type: standard
     ref: v4.551.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-  - name: golangci/golangci-lint@v2.12.2
+  - name: golangci/golangci-lint@v2.13.1
   - name: evilmartians/lefthook@v2.1.10
   - name: suzuki-shunsuke/pinact@v4.1.1
   - name: zizmorcore/zizmor@v1.29.0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,8 @@ func main() {
 	}
 	{
 		dummy := bytes.Repeat([]byte{0xFF}, 128)
-		gociphertext, _ := rsa.EncryptPKCS1v15(bytes.NewBuffer(dummy), &key.PublicKey, plaintext)
+		// Keep the deprecated call to compare the toy PKCS #1 v1.5 implementation with the standard library.
+		gociphertext, _ := rsa.EncryptPKCS1v15(bytes.NewBuffer(dummy), &key.PublicKey, plaintext) //nolint:staticcheck
 		fmt.Printf("%X\n", gociphertext)
 
 		ciphertext, _ := toyrsa.EncryptPKCS1v15(bytes.NewBuffer(dummy), n, big.NewInt(int64(e)), plaintext)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/blck-snwmn/toyrsa
 
-go 1.24.0
+go 1.27.0

--- a/pkcs1v15_test.go
+++ b/pkcs1v15_test.go
@@ -34,7 +34,8 @@ func Test_EncryptPKCS1v15(t *testing.T) {
 	}
 
 	for i := 0; i < 1000; i++ {
-		gociphertext, _ := rsa.EncryptPKCS1v15(rand.Reader, &key.PublicKey, plaintext)
+		// Keep the deprecated call to compare the toy PKCS #1 v1.5 implementation with the standard library.
+		gociphertext, _ := rsa.EncryptPKCS1v15(rand.Reader, &key.PublicKey, plaintext) //nolint:staticcheck
 		ciphertext, err := EncryptPKCS1v15(genReader(gociphertext), n, e, plaintext)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Updates Go module directives to 1.27.0. Verified with Go 1.27.0 using go test ./... for every module in this repository. Also updates golangci-lint to v2.13.1 and documents the intentional deprecated PKCS #1 v1.5 comparison; lint passes.