### PR TITLE
ci: enforce golangci-lint v2 formatting

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -25,13 +25,12 @@ jobs:
         with:
           aqua_version: v2.62.3
 
-      - parallel:
-          - name: Check action pinning
-            run: pinact run --check
-            env:
-              GITHUB_TOKEN: ${{ github.token }}
+      - name: Check action pinning
+        run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
-          - name: Audit workflows
-            run: zizmor --format github .
-            env:
-              GH_TOKEN: ${{ github.token }}
+      - name: Audit workflows
+        run: zizmor --format github .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 name: Go test&lint
 
 on:
+  pull_request:
   push:
 
 
@@ -14,6 +15,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
       - name: Run test
         run: |
           go test ./... --shuffle on --parallel 10 --p 10
@@ -26,6 +29,9 @@ jobs:
       - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         with:
           aqua_version: v2.62.3
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
       - name: Run lint
         run: |
-          golangci-lint run --enable=gosec
+          golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  enable:
+    - gosec
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
   commands:
     lint:
       glob: "*.go"
-      run: golangci-lint run --enable=gosec
+      run: golangci-lint run
     test:
       glob: "*.go"
       run: go test ./... --shuffle on --parallel 10 --p 10


### PR DESCRIPTION
## Summary
- add a golangci-lint v2 configuration that keeps gosec enabled and checks gofmt/goimports
- run the aqua-managed golangci-lint on push and pull requests, with Go resolved from go.mod
- restore valid, separate pinact and zizmor security steps
- keep the existing Go version unchanged (go.mod currently declares Go 1.24.0; CI reads that source of truth)

## Validation
- `golangci-lint version` (aqua-pinned v2.12.2)
- `golangci-lint config verify`
- `golangci-lint run` (local process lock required `--allow-parallel-runners`; 0 issues)
- `go test ./... --shuffle on --parallel 10 --p 10`
- `pinact run --check`
- `zizmor --format plain .`
- YAML parse validation for workflows and tool configuration
- `git diff --check`